### PR TITLE
v1.4.02

### DIFF
--- a/ATL/CHANGEDB.php
+++ b/ATL/CHANGEDB.php
@@ -67,3 +67,8 @@ $sql[$count][1] = '';
 $sql[$count][0] = '1.4.01';
 $sql[$count][1] = '';
 
+//v1.4.02
+++$count;
+$sql[$count][0] = '1.4.02';
+$sql[$count][1] = '';
+

--- a/ATL/CHANGELOG.txt
+++ b/ATL/CHANGELOG.txt
@@ -1,5 +1,9 @@
 CHANGELOG
 =========
+v1.4.02
+-------
+Fix a file-include related error in dashboard hooks
+
 v1.4.01
 -------
 Minor fixes to breadcrumbs

--- a/ATL/hook_parentalDashboard_atlView.php
+++ b/ATL/hook_parentalDashboard_atlView.php
@@ -19,17 +19,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 $returnInt = null;
 
-//Only include module include if it is not already included (which it may be been on the index page)
-$included = false;
-$includes = get_included_files();
-foreach ($includes as $include) {
-    if ($include == $_SESSION[$guid]['absolutePath'].'/modules/ATL/moduleFunctions.php') {
-        $included = true;
-    }
-}
-if ($included == false) {
-    include './modules/ATL/moduleFunctions.php';
-}
+require_once './modules/ATL/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/ATL/atl_view.php') == false) {
     //Acess denied

--- a/ATL/hook_studentDashboard_atlView.php
+++ b/ATL/hook_studentDashboard_atlView.php
@@ -19,17 +19,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 $returnInt = null;
 
-//Only include module include if it is not already included (which it may be been on the index page)
-$included = false;
-$includes = get_included_files();
-foreach ($includes as $include) {
-    if ($include == $_SESSION[$guid]['absolutePath'].'/modules/ATL/moduleFunctions.php') {
-        $included = true;
-    }
-}
-if ($included == false) {
-    include './modules/ATL/moduleFunctions.php';
-}
+require_once './modules/ATL/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/ATL/atl_view.php') == false) {
     //Acess denied

--- a/ATL/hook_studentProfile_atlView.php
+++ b/ATL/hook_studentProfile_atlView.php
@@ -18,7 +18,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 //Module includes
-include './modules/ATL/moduleFunctions.php';
+require_once './modules/ATL/moduleFunctions.php';
 
 if (isActionAccessible($guid, $connection2, '/modules/ATL/atl_view.php') == false) {
     //Acess denied

--- a/ATL/manifest.php
+++ b/ATL/manifest.php
@@ -25,7 +25,7 @@ $description = 'The ATL module allows schools to run a program of Approaches To 
 $entryURL = 'atl_write.php';
 $type = 'Additional';
 $category = 'Assess';
-$version = '1.4.01';
+$version = '1.4.02';
 $author = 'Ross Parker';
 $url = 'http://rossparker.org';
 

--- a/ATL/moduleFunctions.php
+++ b/ATL/moduleFunctions.php
@@ -117,6 +117,7 @@ function sidebarExtra($guid, $connection2, $gibbonCourseClassID, $mode = 'manage
 {
     $output = '';
 
+    $output .= '<div class="column-no-break">';
     $output .= '<h2>';
     $output .= __('View Classes');
     $output .= '</h2>';
@@ -137,6 +138,7 @@ function sidebarExtra($guid, $connection2, $gibbonCourseClassID, $mode = 'manage
         $row->addSubmit(__('Go'));
     
     $output .= $form->getOutput();
+    $output .= '</div>';
 
     return $output;
 }

--- a/ATL/version.php
+++ b/ATL/version.php
@@ -20,4 +20,4 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 /**
  * Sets version information.
  */
-$moduleVersion = '1.4.01';
+$moduleVersion = '1.4.02';


### PR DESCRIPTION
Fixes a file-include related error in parent dashboard hooks. If a parent has multiple children, the moduleFunctions was being included more than once, causing a fatal PHP error because the functions in that file had already been defined. Switches the `include`s to a `require_once`.